### PR TITLE
move mappings init to onEndResolve so that plugin options are initialized

### DIFF
--- a/src/SourcefileUrlMapPlugin.ts
+++ b/src/SourcefileUrlMapPlugin.ts
@@ -19,31 +19,7 @@ export class SourcefileUrlMapPlugin extends ConverterComponent {
 
     public initialize(): void
     {
-        // read options parameter
-        const options: Options = this.application.options
-        options.read({}, OptionsReadMode.Prefetch)
-        const mapRelativePath = options.getValue('sourcefile-url-map')
-        const urlPrefix = options.getValue('sourcefile-url-prefix')
-
-        if ( (typeof mapRelativePath !== 'string') && (typeof urlPrefix !== 'string') ) {
-            return
-        }
-
         try {
-            if ( (typeof mapRelativePath === 'string') && (typeof urlPrefix === 'string') ) {
-                throw new Error('use either --sourcefile-url-prefix or --sourcefile-url-map option')
-            }
-
-            if ( typeof mapRelativePath === 'string' ) {
-                this.readMappingJson(mapRelativePath)
-            }
-            else if ( typeof urlPrefix === 'string' ) {
-                this.mappings = [{
-                    pattern: new RegExp('^'),
-                    replace: urlPrefix
-                }]
-            }
-
             // register handler
             this.listenTo(this.owner, Converter.EVENT_RESOLVE_END, this.onEndResolve)
         }
@@ -97,6 +73,36 @@ export class SourcefileUrlMapPlugin extends ConverterComponent {
 
     private onEndResolve(context: Context): void
     {
+        // read options parameter
+        const options: Options = this.application.options
+        options.read({}, OptionsReadMode.Prefetch)
+        const mapRelativePath = options.getValue('sourcefile-url-map')
+        const urlPrefix = options.getValue('sourcefile-url-prefix')
+
+        if ( (typeof mapRelativePath !== 'string') && (typeof urlPrefix !== 'string') ) {
+            return
+        }
+
+        try {
+            if ( (typeof mapRelativePath === 'string') && (typeof urlPrefix === 'string') ) {
+                throw new Error('use either --sourcefile-url-prefix or --sourcefile-url-map option')
+            }
+
+            if ( typeof mapRelativePath === 'string' ) {
+                this.readMappingJson(mapRelativePath)
+            }
+            else if ( typeof urlPrefix === 'string' ) {
+                this.mappings = [{
+                    pattern: new RegExp('^'),
+                    replace: urlPrefix
+                }]
+            }
+
+        }
+        catch ( e ) {
+            console.error('typedoc-plugin-sourcefile-url: ' + e.message)
+        }
+
         if ( this.mappings === undefined ) {
             throw new Error('assertion fail')
         }


### PR DESCRIPTION
As mentioned in #1, I'm not sure if this is a general issue or just an issue when using with gulp-typedoc.  In the case of gulp-typedoc, the plugin options (sourcefile-url-map and sourcefile-url-prefix) are not available at the time plugin.initialize is called so mappings does not get correctly inited.  Waiting until onEndResolve to init mappings fixes this.

Let me know if you need more information.