### PR TITLE
fix option value handling for use with recent typedoc versions

### DIFF
--- a/src/SourcefileUrlMapPlugin.ts
+++ b/src/SourcefileUrlMapPlugin.ts
@@ -29,19 +29,22 @@ export class SourcefileUrlMapPlugin extends ConverterComponent {
         const mapRelativePath = options.getValue('sourcefile-url-map')
         const urlPrefix = options.getValue('sourcefile-url-prefix')
 
-        if ( (typeof mapRelativePath !== 'string') && (typeof urlPrefix !== 'string') ) {
+    		const isMapRelativePath = typeof mapRelativePath === 'string' && mapRelativePath
+    		const isUrlPrefix = typeof urlPrefix === 'string' && urlPrefix
+
+        if ( !isMapRelativePath && !isUrlPrefix ) {
             return
         }
 
         try {
-            if ( (typeof mapRelativePath === 'string') && (typeof urlPrefix === 'string') ) {
+            if ( isMapRelativePath && isUrlPrefix ) {
                 throw new Error('use either --sourcefile-url-prefix or --sourcefile-url-map option')
             }
 
-            if ( typeof mapRelativePath === 'string' ) {
+            if ( isMapRelativePath ) {
                 this.readMappingJson(mapRelativePath)
             }
-            else if ( typeof urlPrefix === 'string' ) {
+            else if ( isUrlPrefix ) {
                 this.mappings = [{
                     pattern: new RegExp('^'),
                     replace: urlPrefix

--- a/src/SourcefileUrlMapPlugin.ts
+++ b/src/SourcefileUrlMapPlugin.ts
@@ -29,8 +29,8 @@ export class SourcefileUrlMapPlugin extends ConverterComponent {
         const mapRelativePath = options.getValue('sourcefile-url-map')
         const urlPrefix = options.getValue('sourcefile-url-prefix')
 
-    		const isMapRelativePath = typeof mapRelativePath === 'string' && mapRelativePath
-    		const isUrlPrefix = typeof urlPrefix === 'string' && urlPrefix
+        const isMapRelativePath = typeof mapRelativePath === 'string' && mapRelativePath
+        const isUrlPrefix = typeof urlPrefix === 'string' && urlPrefix
 
         if ( !isMapRelativePath && !isUrlPrefix ) {
             return


### PR DESCRIPTION
Fixes the issue that the plugin always aborts with message
```
use either --sourcefile-url-prefix or --sourcefile-url-map option
```
when used with recent versions of `typedoc`

this may address / solve the problem that is described in issue #8 

__Cause__

recent `typedoc` versions return an empty string for unset (String) option values

since this plugin only allows either `--sourcefile-url-prefix` or `--sourcefile-url-map`, it will abort if both are applied

for this to work correctly, it must determine if both options are applied, but currently it only checks if both options are valid strings
as a result, it will currently always abort, since unset options are returned as empty strings by `typedoc`

__Solution__

in addition to checking of an option is a valid string, also verify that it is not an empty string
